### PR TITLE
Add files via upload

### DIFF
--- a/nature/tree-palm-14.svg
+++ b/nature/tree-palm-14.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="100%"
+   height="100%"
+   viewBox="0 0 14 14"
+   id="svg2"
+   sodipodi:docname="tree-palm-14.svg"
+   inkscape:version="0.92.1 r15371">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview7"
+     showgrid="true"
+     inkscape:zoom="33.714286"
+     inkscape:cx="7.1243687"
+     inkscape:cy="6.2295135"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4484" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <rect
+     width="14"
+     height="14"
+     x="0"
+     y="0"
+     id="canvas"
+     style="fill:none;stroke:none;visibility:hidden" />
+  <path
+     d="M 7.75,14 7.4237288,8.3601695 9.1186441,10.525424 C 10.674624,12.513188 10.320735,7.9449153 7.7754237,6.9449153 9.3486395,6.7030554 12.35226,13 11,6.3983051 11,6.3983051 10,4 7.7399709,5.7853316 7.4071658,6.0482343 7.1245519,1.4339407 7,2.2161017 6.6829287,4.2072474 6.3347458,5.8050847 6.3347458,5.8050847 4.8608246,4.6137952 3.3260043,4.9718032 2.970456,6.553461 1.5213083,13 5.5642931,6.4000962 6.4025424,6.9449153 c -2.5033641,1 -2.8236772,5.6318647 -1.4322034,3.5508477 L 6.6059322,8.3305085 6.25,14 Z"
+     id="tree-deciduous"
+     style="fill:#000000;fill-opacity:1;stroke:none"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsccsscscsccc" />
+</svg>


### PR DESCRIPTION
Palm icon is proposed, as the tag:leaf_type supports the palm type. Several species that make up the urban trees are represented with this type of leaves. Although they are not very common trees in cities, the tag:leaf_type=broadleaved icon is not very representative for them.
The icon should be improved, I do not manage in the svg format.